### PR TITLE
info.xml: fix broken urls

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -9,8 +9,8 @@
     <email>helpdesk@civicoop.org</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">https://guthub.com/CiviCooP/org.civicoop.pdfapi</url>
-    <url desc="Documentation">https://guthub.com/CiviCooP/org.civicoop.pdfapi/README.md</url>
+    <url desc="Main Extension Page">https://github.com/CiviCooP/org.civicoop.pdfapi</url>
+    <url desc="Documentation">https://github.com/CiviCooP/org.civicoop.pdfapi/blob/master/README.md</url>
     <url desc="Support">http://civicoop.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>


### PR DESCRIPTION
The GitHub urls were broken because of typos.