### PR TITLE
Add option for using the email template subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Parameters for the api are specified below:
 - to_email: e-mail address where the pdf file is send to
 - pdf_format_id: (optional) ID of the PDF format, is not especified the default PDF format is used
 - template_email_id: (optional) ID of the message template which will be used to generate the email body.
+- template_email_use_subject: (optional) Use the message subject of the template email. 0 is false and 1 or highter is true.


### PR DESCRIPTION
Add an option for using the subject from the email template that is defined in the template_email_id parameter. Useful for custom subjects apart from the message template title and default "PDF Letter from Civicrm - " prefix.