### PR TITLE
don't create a second CiviRuleAction on reinstall

### DIFF
--- a/CRM/Pdfapi/Upgrader.php
+++ b/CRM/Pdfapi/Upgrader.php
@@ -15,7 +15,7 @@ class CRM_Pdfapi_Upgrader extends CRM_Pdfapi_Upgrader_Base {
   public function install() {
     // if CiviRules installed
     try {
-      $extensions = civicrm_api3('Extension', 'get');
+      $extensions = civicrm_api3('Extension', 'get', ['options' => ['limit' => 0]]);
       foreach($extensions['values'] as $ext) {
         if ($ext['key'] == 'org.civicoop.civirules' && $ext['status'] == 'installed') {
           if (civicrm_api3('CiviRuleAction', 'getcount', ['name' => "pdfapi_send"]) === 0) {
@@ -59,7 +59,7 @@ class CRM_Pdfapi_Upgrader extends CRM_Pdfapi_Upgrader_Base {
     $this->ctx->log->info('Applying update 1002 (introduce email body template and email subject');
     // if CiviRules installed
     try {
-      $extensions = civicrm_api3('Extension', 'get');
+      $extensions = civicrm_api3('Extension', 'get', ['options' => ['limit' => 0]]);
       foreach($extensions['values'] as $ext) {
         if ($ext['key'] == 'org.civicoop.civirules' &&$ext['status'] == 'installed') {
 
@@ -105,7 +105,7 @@ class CRM_Pdfapi_Upgrader extends CRM_Pdfapi_Upgrader_Base {
     $this->ctx->log->info('Applying update 1002 (introduce email and/or pdf activity)');
     // if CiviRules installed
     try {
-      $extensions = civicrm_api3('Extension', 'get');
+      $extensions = civicrm_api3('Extension', 'get', ['options' => ['limit' => 0]]);
       foreach($extensions['values'] as $ext) {
         if ($ext['key'] == 'org.civicoop.civirules' &&$ext['status'] == 'installed') {
 

--- a/CRM/Pdfapi/Upgrader.php
+++ b/CRM/Pdfapi/Upgrader.php
@@ -35,7 +35,7 @@ class CRM_Pdfapi_Upgrader extends CRM_Pdfapi_Upgrader_Base {
     $this->ctx->log->info('Applying update 1001 (remove managed entity');
     // if CiviRules installed
     try {
-      $extensions = civicrm_api3('Extension', 'get');
+      $extensions = civicrm_api3('Extension', 'get', ['options' => ['limit' => 0]]);
       foreach($extensions['values'] as $ext) {
         if ($ext['key'] == 'org.civicoop.civirules' &&$ext['status'] == 'installed') {
           if (CRM_Core_DAO::checkTableExists('civicrm_managed')) {

--- a/CRM/Pdfapi/Upgrader.php
+++ b/CRM/Pdfapi/Upgrader.php
@@ -17,11 +17,14 @@ class CRM_Pdfapi_Upgrader extends CRM_Pdfapi_Upgrader_Base {
     try {
       $extensions = civicrm_api3('Extension', 'get');
       foreach($extensions['values'] as $ext) {
-        if ($ext['key'] == 'org.civicoop.civirules' &&$ext['status'] == 'installed') {
-          $this->executeSqlFile('sql/insertSendPDFAction.sql');
+        if ($ext['key'] == 'org.civicoop.civirules' && $ext['status'] == 'installed') {
+          if (civicrm_api3('CiviRuleAction', 'getcount', ['name' => "pdfapi_send"]) === 0) {
+            $this->executeSqlFile('sql/insertSendPDFAction.sql');
+          }
         }
       }
-    } catch (CiviCRM_API3_Exception $ex) {
+    }
+    catch (CiviCRM_API3_Exception $ex) {
     }
   }
 


### PR DESCRIPTION
The current approach to adding the CiviRuleAction handles installation of a new entry but not its removal.  I assume this is intentional.  However, we should ensure that if we uninstall and reinstall we don't create a second (etc.) CiviRuleAction.